### PR TITLE
configure: Automaticaly detect the default xorg-module-dir.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,11 @@
 #  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 #  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-DISTCHECK_CONFIGURE_FLAGS = --with-sdkdir=\$${includedir}/xorg
+# During distcheck, system locations (as provided by pkg-config) may
+# not be writable; provide instead relative locations.
+DISTCHECK_CONFIGURE_FLAGS = --with-xorg-module-dir='$${libdir}/xorg/modules' \
+                            --with-sdkdir='$${includedir}/xorg'
+
 SUBDIRS = src man config include
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -57,11 +57,12 @@ AC_SUBST([DRIVER_NAME])
 #			Configuration options
 # -----------------------------------------------------------------------------
 # Define a configure option for an alternate input module directory
+PKG_PROG_PKG_CONFIG([0.25])
 AC_ARG_WITH(xorg-module-dir,
             AS_HELP_STRING([--with-xorg-module-dir=DIR],
-                           [Default xorg module directory [[default=$libdir/xorg/modules]]]),
+                           [Default xorg module directory]),
             [moduledir="$withval"],
-            [moduledir="$libdir/xorg/modules"])
+            [moduledir=`$PKG_CONFIG --variable=moduledir xorg-server`])
 inputdir=${moduledir}/input
 AC_SUBST(inputdir)
 


### PR DESCRIPTION
The module directory has changed to a per ABI folder in the xlibre-xserver.
Now the default value of `xorg-module-dir` will be detected from the 'moduledir' variable in xorg-server.pc.