### PR TITLE
make return value of jstkInitProperties() void

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ joystick_drv_la_SOURCES =  jstk.c jstk.h \
 				jstk_axis.c jstk_axis.h \
 				jstk_key.c jstk_key.h \
 				jstk_options.c jstk_options.h \
-				jstk_properties.c jstk_properties.h
+				jstk_properties.c
 
 BSD_SRCS   = backend_bsd.c backend_bsd.h
 LINUX_SRCS = backend_joystick.c backend_joystick.h

--- a/src/jstk.c
+++ b/src/jstk.c
@@ -42,7 +42,6 @@
 #include "jstk_axis.h"
 #include "jstk_key.h"
 #include "jstk_options.h"
-#include "jstk_properties.h"
 #include <xserver-properties.h>
 
 #ifdef LINUX_BACKEND

--- a/src/jstk.h
+++ b/src/jstk.h
@@ -128,5 +128,6 @@ typedef struct _JoystickDevRec {
 } JoystickDevRec;
 
 void jstkCloseDevice(JoystickDevPtr priv);
+void jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv);
 
 #endif

--- a/src/jstk_properties.c
+++ b/src/jstk_properties.c
@@ -32,7 +32,6 @@
 #include <exevents.h>
 
 #include "jstk.h"
-#include "jstk_properties.h"
 #include "joystick-properties.h" /* definitions of properties */
 
 
@@ -272,8 +271,7 @@ jstkSetProperty(DeviceIntPtr pJstk, Atom atom, XIPropertyValuePtr val,
     return Success;
 }
 
-Bool
-jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv)
+void jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv)
 {
     INT32 axes_values32[MAXAXES];
     INT8  axes_values8[MAXAXES*MAXKEYSPERBUTTON];
@@ -292,7 +290,6 @@ jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv)
                                "Disabling support for float properties.\n", pJstk->name);
         }
     }
-
 
 #ifdef DEBUG
     /* Debug Level */
@@ -447,6 +444,4 @@ jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv)
                                 button_values8,
                                 FALSE);
     XISetDevicePropertyDeletable(pJstk, prop_button_keys, FALSE);
-
-    return TRUE;
 }

--- a/src/jstk_properties.h
+++ b/src/jstk_properties.h
@@ -26,6 +26,6 @@
 
 #include "jstk.h"
 
-Bool jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv);
+void jstkInitProperties(DeviceIntPtr pJstk, JoystickDevPtr priv);
 
 #endif


### PR DESCRIPTION
Nobody's looking at it, and it's always TRUE, so not needed at all.