### PR TITLE
configure.ac: use AC_CONFIG_FILES() macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,8 +93,6 @@ if test "x$evdev_backend" = xyes; then
     AC_DEFINE(EVDEV_BACKEND, 1, [Compile Linux evdev backend])
 fi
 
-AC_OUTPUT([Makefile src/Makefile man/Makefile man/joystick.man config/Makefile])
-
 AS_ECHO()
 AS_ECHO("Building Linux joystick backend: $linux_backend")
 AS_ECHO("Building Linux evdev backend: $evdev_backend")
@@ -107,3 +105,6 @@ if test "x$linux_backend" != "xyes" -a \
                   supported by the joystick driver. Contact
                   xlibre@freelists.org if you are interested in porting it.])
 fi
+
+AC_CONFIG_FILES([Makefile src/Makefile man/Makefile man/joystick.man config/Makefile])
+AC_OUTPUT


### PR DESCRIPTION
passing output file names to AC_OUTPUT() is deprecated.